### PR TITLE
fix: アップロードモードでの画像保存バグを修正し、ソースモードタブを拡大

### DIFF
--- a/src/components/Gacha/ResultActions.tsx
+++ b/src/components/Gacha/ResultActions.tsx
@@ -42,14 +42,35 @@ export const ResultActions = ({ result, onRetry, isVisible }: ResultActionsProps
 
         // videoのフレームをcanvasに描画
         tempCanvas = document.createElement('canvas');
-        const videoWidth = video.videoWidth || video.clientWidth;
-        const videoHeight = video.videoHeight || video.clientHeight;
-        tempCanvas.width = videoWidth;
-        tempCanvas.height = videoHeight;
 
-        const ctx = tempCanvas.getContext('2d');
-        if (ctx) {
-          ctx.drawImage(video, 0, 0, videoWidth, videoHeight);
+        // 画像がposterとして設定されている場合（アップロードされた画像）
+        const posterUrl = video.poster;
+        if (posterUrl && posterUrl !== '') {
+          // posterから画像を取得してcanvasに描画
+          const img = new Image();
+          img.crossOrigin = 'anonymous';
+          await new Promise<void>((resolve, reject) => {
+            img.onload = () => resolve();
+            img.onerror = () => reject(new Error('Image load failed'));
+            img.src = posterUrl;
+          });
+          tempCanvas.width = img.naturalWidth || video.clientWidth;
+          tempCanvas.height = img.naturalHeight || video.clientHeight;
+          const ctx = tempCanvas.getContext('2d');
+          if (ctx) {
+            ctx.drawImage(img, 0, 0, tempCanvas.width, tempCanvas.height);
+          }
+        } else {
+          // 動画またはカメラの場合
+          const videoWidth = video.videoWidth || video.clientWidth;
+          const videoHeight = video.videoHeight || video.clientHeight;
+          tempCanvas.width = videoWidth;
+          tempCanvas.height = videoHeight;
+
+          const ctx = tempCanvas.getContext('2d');
+          if (ctx) {
+            ctx.drawImage(video, 0, 0, videoWidth, videoHeight);
+          }
         }
 
         // videoと同じスタイルを適用

--- a/src/components/UI/SourceModeTab.tsx
+++ b/src/components/UI/SourceModeTab.tsx
@@ -73,7 +73,7 @@ export const SourceModeTab = ({
           {/* Camera tab */}
           <button
             onClick={handleCameraClick}
-            className="relative flex items-center gap-2 px-5 py-3 transition-all duration-300"
+            className="relative flex items-center gap-2.5 px-6 py-4 transition-all duration-300"
           >
             {currentMode === 'camera' && (
               <motion.div
@@ -90,14 +90,14 @@ export const SourceModeTab = ({
               </motion.div>
             )}
             <Camera
-              className={`w-5 h-5 relative z-10 transition-all duration-300 ${
+              className={`w-6 h-6 relative z-10 transition-all duration-300 ${
                 currentMode === 'camera'
                   ? 'text-amber-300 drop-shadow-[0_0_8px_rgba(251,191,36,0.6)]'
                   : 'text-gray-400'
               }`}
             />
             <span
-              className={`relative z-10 font-bold text-sm tracking-wide transition-all duration-300 ${
+              className={`relative z-10 font-bold text-base tracking-wide transition-all duration-300 ${
                 currentMode === 'camera'
                   ? 'text-amber-100 drop-shadow-[0_0_8px_rgba(251,191,36,0.4)]'
                   : 'text-gray-400'
@@ -115,7 +115,7 @@ export const SourceModeTab = ({
           {/* File tab */}
           <button
             onClick={handleFileTabClick}
-            className="relative flex items-center gap-2 px-5 py-3 transition-all duration-300"
+            className="relative flex items-center gap-2.5 px-6 py-4 transition-all duration-300"
           >
             {currentMode === 'file' && (
               <motion.div
@@ -132,14 +132,14 @@ export const SourceModeTab = ({
               </motion.div>
             )}
             <ImageIcon
-              className={`w-5 h-5 relative z-10 transition-all duration-300 ${
+              className={`w-6 h-6 relative z-10 transition-all duration-300 ${
                 currentMode === 'file'
                   ? 'text-amber-300 drop-shadow-[0_0_8px_rgba(251,191,36,0.6)]'
                   : 'text-gray-400'
               }`}
             />
             <span
-              className={`relative z-10 font-bold text-sm tracking-wide transition-all duration-300 whitespace-nowrap ${
+              className={`relative z-10 font-bold text-base tracking-wide transition-all duration-300 whitespace-nowrap ${
                 currentMode === 'file'
                   ? 'text-amber-100 drop-shadow-[0_0_8px_rgba(251,191,36,0.4)]'
                   : 'text-gray-400'


### PR DESCRIPTION
## 概要

アップロードモードで画像保存ができないバグを修正し、ソースモード切り替えタブのUIを改善しました。

## 変更内容

### 🐛 バグ修正: アップロードモードでの画像保存

**問題**
- 画像をアップロードしてガチャを引いた後、「保存」ボタンを押しても正しく画像が保存されなかった
- 原因: アップロードされた画像は `video.poster` に設定されるため、`video.videoWidth` / `video.videoHeight` が `0` になり、canvasへの描画が失敗していた

**修正内容**
- `video.poster` が設定されている場合は、`Image` オブジェクトとして読み込んでからcanvasに描画するように変更
- `img.naturalWidth` / `img.naturalHeight` を使用して正しいサイズでキャプチャ

### 🎨 UI改善: ソースモードタブの拡大

タップしやすさを向上させるため、「カメラ」「画像・動画から」タブを拡大しました。

| 項目 | Before | After |
|------|--------|-------|
| パディング | `px-5 py-3` | `px-6 py-4` |
| アイコンサイズ | `w-5 h-5` | `w-6 h-6` |
| フォントサイズ | `text-sm` | `text-base` |
| gap | `gap-2` | `gap-2.5` |

## 変更ファイル

- `src/components/Gacha/ResultActions.tsx` - 画像保存ロジックの修正
- `src/components/UI/SourceModeTab.tsx` - タブUIのサイズ拡大

## テスト方法

1. 画像をアップロードしてガチャを引く
2. 結果画面で「保存」ボタンをタップ
3. 画像が正しく保存されることを確認
4. ソースモードタブが以前より大きく表示されることを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
